### PR TITLE
Add versions of the route-adding methods that include a "validator" block.

### DIFF
--- a/JLRoutes.podspec
+++ b/JLRoutes.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "JLRoutes"
-  s.version      = "1.5.2"
+  s.version      = "1.6.0"
   s.summary      = "Advanced URL parsing designed to handle complex URL schemes with a block-based callback API."
   s.homepage     = "https://github.com/joeldev/JLRoutes"
 

--- a/JLRoutes/JLRoutes.h
+++ b/JLRoutes/JLRoutes.h
@@ -38,6 +38,12 @@ static NSString *const kJLRoutesGlobalNamespaceKey = @"JLRoutesGlobalNamespace";
 /// Registers a routePattern with default priority (0) in the receiving scheme namespace.
 + (void)addRoute:(NSString *)routePattern handler:(BOOL (^)(NSDictionary *parameters))handlerBlock;
 - (void)addRoute:(NSString *)routePattern handler:(BOOL (^)(NSDictionary *parameters))handlerBlock; // instance method
++ (void)addRoute:(NSString *)routePattern
+       validator:(BOOL (^)(NSDictionary *parameters))validatorBlock
+         handler:(BOOL (^)(NSDictionary *parameters))handlerBlock;
+- (void)addRoute:(NSString *)routePattern
+       validator:(BOOL (^)(NSDictionary *parameters))validatorBlock
+         handler:(BOOL (^)(NSDictionary *parameters))handlerBlock; // instance method
 
 /// Removes a routePattern from the receiving scheme namespace.
 + (void)removeRoute:(NSString *)routePattern;
@@ -58,6 +64,14 @@ static NSString *const kJLRoutesGlobalNamespaceKey = @"JLRoutesGlobalNamespace";
 /// a block returns NO, JLRoutes will continue trying to find a matching route.
 + (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(BOOL (^)(NSDictionary *parameters))handlerBlock;
 - (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(BOOL (^)(NSDictionary *parameters))handlerBlock; // instance method
++ (void)addRoute:(NSString *)routePattern
+        priority:(NSUInteger)priority
+       validator:(BOOL (^)(NSDictionary *parameters))validatorBlock
+         handler:(BOOL (^)(NSDictionary *parameters))handlerBlock;
+- (void)addRoute:(NSString *)routePattern
+        priority:(NSUInteger)priority
+       validator:(BOOL (^)(NSDictionary *parameters))validatorBlock
+         handler:(BOOL (^)(NSDictionary *parameters))handlerBlock; // instance method
 
 /// Routes a URL, calling handler blocks (for patterns that match URL) until one returns YES, optionally specifying add'l parameters
 + (BOOL)routeURL:(NSURL *)URL;

--- a/JLRoutes/JLRoutes.h
+++ b/JLRoutes/JLRoutes.h
@@ -19,6 +19,7 @@ static NSString *const kJLRouteNamespaceKey = @"JLRouteNamespace";
 static NSString *const kJLRouteWildcardComponentsKey = @"JLRouteWildcardComponents";
 static NSString *const kJLRoutesGlobalNamespaceKey = @"JLRoutesGlobalNamespace";
 
+typedef BOOL(^JLRoutesHandler)(NSDictionary *parameters);
 
 @interface JLRoutes : NSObject
 /** @class JLRoutes
@@ -36,14 +37,14 @@ static NSString *const kJLRoutesGlobalNamespaceKey = @"JLRoutesGlobalNamespace";
 + (BOOL)shouldDecodePlusSymbols;
 
 /// Registers a routePattern with default priority (0) in the receiving scheme namespace.
-+ (void)addRoute:(NSString *)routePattern handler:(BOOL (^)(NSDictionary *parameters))handlerBlock;
-- (void)addRoute:(NSString *)routePattern handler:(BOOL (^)(NSDictionary *parameters))handlerBlock; // instance method
++ (void)addRoute:(NSString *)routePattern handler:(JLRoutesHandler)handlerBlock;
+- (void)addRoute:(NSString *)routePattern handler:(JLRoutesHandler)handlerBlock; // instance method
 + (void)addRoute:(NSString *)routePattern
-       validator:(BOOL (^)(NSDictionary *parameters))validatorBlock
-         handler:(BOOL (^)(NSDictionary *parameters))handlerBlock;
+       validator:(JLRoutesHandler)validatorBlock
+         handler:(JLRoutesHandler)handlerBlock;
 - (void)addRoute:(NSString *)routePattern
-       validator:(BOOL (^)(NSDictionary *parameters))validatorBlock
-         handler:(BOOL (^)(NSDictionary *parameters))handlerBlock; // instance method
+       validator:(JLRoutesHandler)validatorBlock
+         handler:(JLRoutesHandler)handlerBlock; // instance method
 
 /// Removes a routePattern from the receiving scheme namespace.
 + (void)removeRoute:(NSString *)routePattern;
@@ -62,16 +63,16 @@ static NSString *const kJLRoutesGlobalNamespaceKey = @"JLRoutesGlobalNamespace";
 /// Registers a routePattern in the global scheme namespace with a handlerBlock to call when the route pattern is matched by a URL.
 /// The block returns a BOOL representing if the handlerBlock actually handled the route or not. If
 /// a block returns NO, JLRoutes will continue trying to find a matching route.
-+ (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(BOOL (^)(NSDictionary *parameters))handlerBlock;
-- (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(BOOL (^)(NSDictionary *parameters))handlerBlock; // instance method
++ (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(JLRoutesHandler)handlerBlock;
+- (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(JLRoutesHandler)handlerBlock; // instance method
 + (void)addRoute:(NSString *)routePattern
         priority:(NSUInteger)priority
-       validator:(BOOL (^)(NSDictionary *parameters))validatorBlock
-         handler:(BOOL (^)(NSDictionary *parameters))handlerBlock;
+       validator:(JLRoutesHandler)validatorBlock
+         handler:(JLRoutesHandler)handlerBlock;
 - (void)addRoute:(NSString *)routePattern
         priority:(NSUInteger)priority
-       validator:(BOOL (^)(NSDictionary *parameters))validatorBlock
-         handler:(BOOL (^)(NSDictionary *parameters))handlerBlock; // instance method
+       validator:(JLRoutesHandler)validatorBlock
+         handler:(JLRoutesHandler)handlerBlock; // instance method
 
 /// Routes a URL, calling handler blocks (for patterns that match URL) until one returns YES, optionally specifying add'l parameters
 + (BOOL)routeURL:(NSURL *)URL;

--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -69,8 +69,8 @@ static BOOL shouldDecodePlusSymbols = YES;
 
 @property (nonatomic, weak) JLRoutes *parentRoutesController;
 @property (nonatomic, strong) NSString *pattern;
-@property (nonatomic, strong) BOOL (^validatorBlock)(NSDictionary *parameters);
-@property (nonatomic, strong) BOOL (^helperBlock)(NSDictionary *parameters);
+@property (nonatomic, copy) JLRoutesHandler validatorBlock;
+@property (nonatomic, copy) JLRoutesHandler helperBlock;
 @property (nonatomic, assign) NSUInteger priority;
 @property (nonatomic, strong) NSArray *patternPathComponents;
 
@@ -235,19 +235,19 @@ static BOOL shouldDecodePlusSymbols = YES;
 	_JLRoute *route = [[_JLRoute alloc] init];
 	route.pattern = routePattern;
 	route.priority = priority;
-    route.validatorBlock = [validatorBlock copy];
-    route.helperBlock = [handlerBlock copy];
+    route.validatorBlock = validatorBlock;
+    route.helperBlock = handlerBlock;
 	route.parentRoutesController = self;
 	
     if (!route.validatorBlock) {
-        route.validatorBlock = [^BOOL (NSDictionary *params) {
+        route.validatorBlock = ^BOOL (NSDictionary *params) {
             return YES;
-        } copy];
+        };
     }
     if (!route.helperBlock) {
-        route.helperBlock = [^BOOL (NSDictionary *params) {
+        route.helperBlock = ^BOOL (NSDictionary *params) {
             return YES;
-        } copy];
+        };
     }
 	
 	if (priority == 0 || self.routes.count == 0) {

--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -194,12 +194,12 @@ static BOOL shouldDecodePlusSymbols = YES;
 
 
 + (void)addRoute:(NSString *)routePattern validator:(JLRoutesHandler)validatorBlock handler:(JLRoutesHandler)handlerBlock {
-    [[self globalRoutes] addRoute:routePattern validator:validatorBlock handler:handlerBlock];
+	[[self globalRoutes] addRoute:routePattern validator:validatorBlock handler:handlerBlock];
 }
 
 
 + (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(JLRoutesHandler)handlerBlock {
-    [[self globalRoutes] addRoute:routePattern priority:priority handler:handlerBlock];
+	[[self globalRoutes] addRoute:routePattern priority:priority handler:handlerBlock];
 }
 
 
@@ -208,7 +208,7 @@ static BOOL shouldDecodePlusSymbols = YES;
        validator:(JLRoutesHandler)validatorBlock
          handler:(JLRoutesHandler)handlerBlock
 {
-    [[self globalRoutes] addRoute:routePattern priority:priority validator:validatorBlock handler:handlerBlock];
+	[[self globalRoutes] addRoute:routePattern priority:priority validator:validatorBlock handler:handlerBlock];
 }
 
 
@@ -218,12 +218,12 @@ static BOOL shouldDecodePlusSymbols = YES;
 
 
 - (void)addRoute:(NSString *)routePattern validator:(JLRoutesHandler)validatorBlock handler:(JLRoutesHandler)handlerBlock {
-    [self addRoute:routePattern priority:0 validator:validatorBlock handler:handlerBlock];
+	[self addRoute:routePattern priority:0 validator:validatorBlock handler:handlerBlock];
 }
 
 
 - (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(JLRoutesHandler)handlerBlock {
-    [self addRoute:routePattern priority:priority validator:nil handler:handlerBlock];
+	[self addRoute:routePattern priority:priority validator:nil handler:handlerBlock];
 }
 
 
@@ -235,42 +235,42 @@ static BOOL shouldDecodePlusSymbols = YES;
 	_JLRoute *route = [[_JLRoute alloc] init];
 	route.pattern = routePattern;
 	route.priority = priority;
-    route.validatorBlock = validatorBlock;
-    route.helperBlock = handlerBlock;
+	route.validatorBlock = validatorBlock;
+	route.helperBlock = handlerBlock;
 	route.parentRoutesController = self;
 	
-    if (!route.validatorBlock) {
-        route.validatorBlock = ^BOOL (NSDictionary *params) {
-            return YES;
-        };
-    }
-    if (!route.helperBlock) {
-        route.helperBlock = ^BOOL (NSDictionary *params) {
-            return YES;
-        };
-    }
+	if (!route.validatorBlock) {
+		route.validatorBlock = ^BOOL (NSDictionary *params) {
+			return YES;
+		};
+	}
+	if (!route.helperBlock) {
+		route.helperBlock = ^BOOL (NSDictionary *params) {
+			return YES;
+		};
+	}
 	
 	if (priority == 0 || self.routes.count == 0) {
 		[self.routes addObject:route];
 	} else {
 		NSArray *existingRoutes = self.routes;
 		NSUInteger index = 0;
-        BOOL addedRoute = NO;
-        
-        // search through existing routes looking for a lower priority route than this one
+		BOOL addedRoute = NO;
+		
+		// search through existing routes looking for a lower priority route than this one
 		for (_JLRoute *existingRoute in existingRoutes) {
 			if (existingRoute.priority < priority) {
-                // if found, add the route after it
+				// if found, add the route after it
 				[self.routes insertObject:route atIndex:index];
-                addedRoute = YES;
+				addedRoute = YES;
 				break;
 			}
 			index++;
 		}
-        
-        // if we weren't able to find a lower priority route, this is the new lowest priority route (or same priority as self.routes.lastObject) and should just be added
-        if (!addedRoute)
-            [self.routes addObject:route];
+		
+		// if we weren't able to find a lower priority route, this is the new lowest priority route (or same priority as self.routes.lastObject) and should just be added
+		if (!addedRoute)
+			[self.routes addObject:route];
 	}
 }
 
@@ -322,16 +322,16 @@ static BOOL shouldDecodePlusSymbols = YES;
 }
 
 + (BOOL)routeURL:(NSURL *)URL withParameters:(NSDictionary *)parameters {
-    return [self routeURL:URL withParameters:parameters executeRouteBlock:YES];
+	return [self routeURL:URL withParameters:parameters executeRouteBlock:YES];
 }
 
 
 + (BOOL)canRouteURL:(NSURL *)URL {
-    return [self routeURL:URL withParameters:nil executeRouteBlock:NO];
+	return [self routeURL:URL withParameters:nil executeRouteBlock:NO];
 }
 
 + (BOOL)canRouteURL:(NSURL *)URL withParameters:(NSDictionary *)parameters {
-    return [self routeURL:URL withParameters:parameters executeRouteBlock:NO];
+	return [self routeURL:URL withParameters:parameters executeRouteBlock:NO];
 }
 
 + (BOOL)routeURL:(NSURL *)URL withParameters:(NSDictionary *)parameters executeRouteBlock:(BOOL)execute {
@@ -395,11 +395,11 @@ static BOOL shouldDecodePlusSymbols = YES;
 #pragma mark Internal API
 
 + (BOOL)routeURL:(NSURL *)URL withController:(JLRoutes *)routesController {
-    return [self routeURL:URL withController:routesController parameters:nil executeBlock:YES];
+	return [self routeURL:URL withController:routesController parameters:nil executeBlock:YES];
 }
 
 + (BOOL)routeURL:(NSURL *)URL withController:(JLRoutes *)routesController parameters:(NSDictionary *)parameters {
-    return [self routeURL:URL withController:routesController parameters:parameters executeBlock:YES];
+	return [self routeURL:URL withController:routesController parameters:parameters executeBlock:YES];
 }
 
 + (BOOL)routeURL:(NSURL *)URL withController:(JLRoutes *)routesController parameters:(NSDictionary *)parameters executeBlock:(BOOL)executeBlock {
@@ -427,9 +427,9 @@ static BOOL shouldDecodePlusSymbols = YES;
 		NSDictionary *matchParameters = [route parametersForURL:URL components:pathComponents];
 		if (matchParameters && route.validatorBlock(matchParameters)) {
 			[self verboseLogWithFormat:@"Successfully matched %@", route];
-            if (!executeBlock) {
-                return YES;
-            }
+			if (!executeBlock) {
+				return YES;
+			}
 
 			// add the URL parameters
 			NSMutableDictionary *finalParameters = [NSMutableDictionary dictionary];
@@ -441,7 +441,7 @@ static BOOL shouldDecodePlusSymbols = YES;
 			[finalParameters addEntriesFromDictionary:parameters];
 			finalParameters[kJLRoutePatternKey] = route.pattern;
 			finalParameters[kJLRouteURLKey] = URL;
-            __strong __typeof(route.parentRoutesController) strongParentRoutesController = route.parentRoutesController;
+			__strong __typeof(route.parentRoutesController) strongParentRoutesController = route.parentRoutesController;
 			finalParameters[kJLRouteNamespaceKey] = strongParentRoutesController.namespaceKey ?: [NSNull null];
 
 			[self verboseLogWithFormat:@"Final parameters are %@", finalParameters];

--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -221,6 +221,7 @@ static BOOL shouldDecodePlusSymbols = YES;
     [self addRoute:routePattern priority:0 validator:validatorBlock handler:handlerBlock];
 }
 
+
 - (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(JLRoutesHandler)handlerBlock {
     [self addRoute:routePattern priority:priority validator:nil handler:handlerBlock];
 }

--- a/JLRoutes/JLRoutes.m
+++ b/JLRoutes/JLRoutes.m
@@ -188,48 +188,48 @@ static BOOL shouldDecodePlusSymbols = YES;
 }
 
 
-+ (void)addRoute:(NSString *)routePattern handler:(BOOL (^)(NSDictionary *parameters))handlerBlock {
++ (void)addRoute:(NSString *)routePattern handler:(JLRoutesHandler)handlerBlock {
 	[[self globalRoutes] addRoute:routePattern handler:handlerBlock];
 }
 
 
-+ (void)addRoute:(NSString *)routePattern validator:(BOOL (^)(NSDictionary *))validatorBlock handler:(BOOL (^)(NSDictionary *))handlerBlock {
++ (void)addRoute:(NSString *)routePattern validator:(JLRoutesHandler)validatorBlock handler:(JLRoutesHandler)handlerBlock {
     [[self globalRoutes] addRoute:routePattern validator:validatorBlock handler:handlerBlock];
 }
 
 
-+ (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(BOOL (^)(NSDictionary *parameters))handlerBlock {
++ (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(JLRoutesHandler)handlerBlock {
     [[self globalRoutes] addRoute:routePattern priority:priority handler:handlerBlock];
 }
 
 
 + (void)addRoute:(NSString *)routePattern
         priority:(NSUInteger)priority
-       validator:(BOOL (^)(NSDictionary *))validatorBlock
-         handler:(BOOL (^)(NSDictionary *))handlerBlock
+       validator:(JLRoutesHandler)validatorBlock
+         handler:(JLRoutesHandler)handlerBlock
 {
     [[self globalRoutes] addRoute:routePattern priority:priority validator:validatorBlock handler:handlerBlock];
 }
 
 
-- (void)addRoute:(NSString *)routePattern handler:(BOOL (^)(NSDictionary *parameters))handlerBlock {
+- (void)addRoute:(NSString *)routePattern handler:(JLRoutesHandler)handlerBlock {
 	[self addRoute:routePattern priority:0 handler:handlerBlock];
 }
 
 
-- (void)addRoute:(NSString *)routePattern validator:(BOOL (^)(NSDictionary *))validatorBlock handler:(BOOL (^)(NSDictionary *))handlerBlock {
+- (void)addRoute:(NSString *)routePattern validator:(JLRoutesHandler)validatorBlock handler:(JLRoutesHandler)handlerBlock {
     [self addRoute:routePattern priority:0 validator:validatorBlock handler:handlerBlock];
 }
 
-- (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(BOOL (^)(NSDictionary *parameters))handlerBlock {
+- (void)addRoute:(NSString *)routePattern priority:(NSUInteger)priority handler:(JLRoutesHandler)handlerBlock {
     [self addRoute:routePattern priority:priority validator:nil handler:handlerBlock];
 }
 
 
 - (void)addRoute:(NSString *)routePattern
         priority:(NSUInteger)priority
-       validator:(BOOL (^)(NSDictionary *))validatorBlock
-         handler:(BOOL (^)(NSDictionary *))handlerBlock
+       validator:(JLRoutesHandler)validatorBlock
+         handler:(JLRoutesHandler)handlerBlock
 {
 	_JLRoute *route = [[_JLRoute alloc] init];
 	route.pattern = routePattern;


### PR DESCRIPTION
If present, the validator block is run during route-matching, if a route appears to match based on the pattern.  If the validator returns YES, the route is considered a match; if the validator returns NO, the route is not considered a match.

@vokal/ios-developers Code review please?
